### PR TITLE
add running.queries and suspended.queries engine runtime metrics

### DIFF
--- a/internal/collector/collect.go
+++ b/internal/collector/collect.go
@@ -98,6 +98,8 @@ func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGrou
 		c.runtimeMetrics.diskUtilization.Record(ctx, mp.DiskUsed, api.WithAttributeSet(attrsSet))
 		c.runtimeMetrics.cacheUtilization.Record(ctx, mp.CacheHitRatio, api.WithAttributeSet(attrsSet))
 		c.runtimeMetrics.diskSpilled.Add(ctx, mp.SpilledBytes, api.WithAttributeSet(attrsSet))
+		c.runtimeMetrics.runningQueries.Record(ctx, mp.RunningQueries, api.WithAttributeSet(attrsSet))
+		c.runtimeMetrics.suspendedQueries.Record(ctx, mp.SuspendedQueries, api.WithAttributeSet(attrsSet))
 	}
 
 	wg.Done()

--- a/internal/collector/metric.go
+++ b/internal/collector/metric.go
@@ -9,6 +9,8 @@ type runtimeMetrics struct {
 	diskUtilization   metric.Float64Gauge
 	cacheUtilization  metric.Float64Gauge
 	diskSpilled       metric.Int64UpDownCounter
+	runningQueries    metric.Int64Gauge
+	suspendedQueries  metric.Int64Gauge
 }
 
 // queryHistoryMetrics specifies a set of engine query history metrics.
@@ -80,6 +82,24 @@ func (c *collector) setupRuntimeMetrics() error {
 		"firebolt.engine.disk.spilled",
 		metric.WithDescription("Amount of spilled data to disk in bytes"),
 		metric.WithUnit("byte"),
+	)
+	if err != nil {
+		return err
+	}
+
+	rm.runningQueries, err = meter.Int64Gauge(
+		"firebolt.engine.running.queries",
+		metric.WithDescription("Number of running queries"),
+		metric.WithUnit("{count}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	rm.suspendedQueries, err = meter.Int64Gauge(
+		"firebolt.engine.suspended.queries",
+		metric.WithDescription("Number of suspended queries"),
+		metric.WithUnit("{count}"),
 	)
 	if err != nil {
 		return err

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -101,7 +101,8 @@ func (f *fetcher) FetchRuntimePoints(ctx context.Context, account string, engine
 				// read the metrics. Only interested in most recent metric within the time interval.
 				row := engDb.QueryRowContext(ctx,
 					fmt.Sprintf(
-						`SELECT engine_cluster, event_time, cpu_used, memory_used, disk_used, cache_hit_ratio, spilled_bytes 
+						`SELECT engine_cluster, event_time, cpu_used, memory_used, disk_used, 
+       						cache_hit_ratio, spilled_bytes, running_queries, suspended_queries  
 				FROM information_schema.engine_metrics_history 
          		WHERE event_time > TIMESTAMPTZ '%s' AND event_time <= TIMESTAMPTZ '%s' 
          		ORDER BY event_time DESC LIMIT 1;`,

--- a/internal/fetcher/model.go
+++ b/internal/fetcher/model.go
@@ -9,13 +9,15 @@ import (
 type EngineRuntimePoint struct {
 	EngineName string
 
-	EngineCluster int64
-	EventTime     time.Time
-	CPUUsed       float64
-	MemoryUsed    float64
-	DiskUsed      float64
-	CacheHitRatio float64
-	SpilledBytes  int64
+	EngineCluster    int64
+	EventTime        time.Time
+	CPUUsed          float64
+	MemoryUsed       float64
+	DiskUsed         float64
+	CacheHitRatio    float64
+	SpilledBytes     int64
+	RunningQueries   int64
+	SuspendedQueries int64
 }
 
 // Scan fills in EngineRuntimePoint fields from a single row.
@@ -28,6 +30,8 @@ func (p *EngineRuntimePoint) Scan(row *sql.Row) error {
 		&p.DiskUsed,
 		&p.CacheHitRatio,
 		&p.SpilledBytes,
+		&p.RunningQueries,
+		&p.SuspendedQueries,
 	)
 }
 


### PR DESCRIPTION
- add `firebolt.engine.running.queries` gauge
- add `firebolt.engine.suspended.queries` gauge