### PR TITLE
chore: change order of queries on connect to an engine

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,6 +32,6 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.60
       - name: Test
         run: go test -vet=all ./...

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -223,16 +223,16 @@ func (f *fetcher) connect(ctx context.Context, accountName string, engineName st
 
 	// switch to the engine if engineName is provided
 	if engineName != "" {
-		// prevent engine from auto stopping caused by exporter queries
-		_, err = db.ExecContext(ctx, `SET auto_start_stop_control=ignore;`)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set auto_start_stop_control = ignore for engine %s: %w", engineName, err)
-		}
-
 		// switch to an engine
 		_, err = db.ExecContext(ctx, fmt.Sprintf(`USE ENGINE "%s";`, engineName))
 		if err != nil {
 			return nil, fmt.Errorf("failed to switch to engine %s: %w", engineName, err)
+		}
+
+		// prevent engine from auto stopping caused by exporter queries
+		_, err = db.ExecContext(ctx, `SET auto_start_stop_control=ignore;`)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set auto_start_stop_control = ignore for engine %s: %w", engineName, err)
 		}
 
 		// add a query label to appear in query history


### PR DESCRIPTION
When a connection to an engine is established, the `SET...` queries must be run after `USE ENGINE..` statement, otherwise they will be discarder