### PR TITLE
feat: collect metrics from engine in RESIZING and DRAINING statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker run --name firebolt-otel-exporter \
   -e FIREBOLT_OTEL_EXPORTER_GRPC_ADDRESS=127.0.0.1:4317 \
   -e FIREBOLT_OTEL_EXPORTER_LOG_LEVEL=debug \
   --network="host" \
-ghcr.io/firebolt-db/otel-exporter:v0.0.5
+ghcr.io/firebolt-db/otel-exporter:v0.0.6
 ```
 
 Meters and instruments
@@ -59,6 +59,7 @@ The exporter's structure of meters and instruments is described below. See [OTLP
 All the instruments in this meter have the following attributes:
  - `firebolt.account.name` - name of the account
  - `firebolt.engine.name` - name of the engine
+ - `firebolt.engine.status` - status of the engine (possible statuses are `RUNNING`, `RESIZING`, `DRAINING`)
 
 ### Meter name: `firebolt.engine.query_history`
 
@@ -79,6 +80,7 @@ All the instruments in this meter have the following attributes:
 - `firebolt.engine.name` - name of the engine
 - `firebolt.user.name` - name of the user executing query
 - `firebolt.query.status` - status of the query
+- `firebolt.engine.status` - status of the engine (possible statuses are `RUNNING`, `RESIZING`, `DRAINING`)
 
 ### Meter name: `firebolt.exporter`
 

--- a/internal/collector/collect.go
+++ b/internal/collector/collect.go
@@ -8,11 +8,13 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/metric"
+
+	"github.com/firebolt-db/otel-exporter/internal/fetcher"
 )
 
 // collectorFn is a function which is responsible for collecting metrics in a single account, with list of engines.
 // It is expected that collectorFn will only collect metrics in time interval between `since` and `till`.
-type collectorFn func(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []string, since, till time.Time)
+type collectorFn func(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []fetcher.Engine, since, till time.Time)
 
 // Start runs main metrics collection routine with specified interval.
 // Start will block until provided context is done, or the app is closed.
@@ -80,7 +82,7 @@ func (c *collector) reportExporterDuration(ctx context.Context, startTime time.T
 }
 
 // collectRuntimeMetrics collects and reports engine runtime metrics, such as cpu utilization, memory utilization etc.
-func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []string, since, till time.Time) {
+func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []fetcher.Engine, since, till time.Time) {
 	slog.DebugContext(ctx, "start collecting runtime metrics", slog.String("accountName", accountName))
 
 	pointsCh := c.fetcher.FetchRuntimePoints(ctx, accountName, engines, since, till)
@@ -89,6 +91,7 @@ func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGrou
 		attrs := []attribute.KeyValue{
 			attribute.Key("firebolt.account.name").String(accountName),
 			attribute.Key("firebolt.engine.name").String(mp.EngineName),
+			attribute.Key("firebolt.engine.status").String(mp.EngineStatus),
 		}
 
 		attrsSet := attribute.NewSet(attrs...)
@@ -108,7 +111,7 @@ func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGrou
 }
 
 // collectQueryHistoryMetrics collects and reports query history metrics, such as rows and bytes scanned, etc.
-func (c *collector) collectQueryHistoryMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []string, since, till time.Time) {
+func (c *collector) collectQueryHistoryMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []fetcher.Engine, since, till time.Time) {
 	slog.DebugContext(ctx, "start collecting query history metrics", slog.String("accountName", accountName))
 
 	pointsCh := c.fetcher.FetchQueryHistoryPoints(ctx, accountName, engines, since, till)
@@ -117,6 +120,7 @@ func (c *collector) collectQueryHistoryMetrics(ctx context.Context, wg *sync.Wai
 		attrs := []attribute.KeyValue{
 			attribute.Key("firebolt.account.name").String(accountName),
 			attribute.Key("firebolt.engine.name").String(mp.EngineName),
+			attribute.Key("firebolt.engine.status").String(mp.EngineStatus),
 			attribute.Key("firebolt.user.name").String(mp.UserName.String),
 			attribute.Key("firebolt.query.status").String(mp.Status.String),
 		}

--- a/internal/collector/collect_test.go
+++ b/internal/collector/collect_test.go
@@ -29,19 +29,22 @@ func Test_Collector_Start(t *testing.T) {
 
 	interval := 25 * time.Millisecond
 
-	eng := []string{"engine1", "engine2"}
-	f.fetchEnginesFn = func(ctx context.Context, accountName string) ([]string, error) {
+	eng := []fetcher.Engine{
+		{Name: "engine1", Status: "RUNNING"},
+		{Name: "engine2", Status: "RESIZING"},
+	}
+	f.fetchEnginesFn = func(ctx context.Context, accountName string) ([]fetcher.Engine, error) {
 		require.Equal(t, acctName, accountName)
 		return eng, nil
 	}
 	rCh := make(chan fetcher.EngineRuntimePoint)
-	f.fetchRuntimePointsFn = func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
+	f.fetchRuntimePointsFn = func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
 		require.Equal(t, acctName, account)
 		require.Equal(t, eng, engines)
 		return rCh
 	}
 	qhCh := make(chan fetcher.QueryHistoryPoint)
-	f.fetchQueryHistoryPointsFn = func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
+	f.fetchQueryHistoryPointsFn = func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 		require.Equal(t, acctName, account)
 		require.Equal(t, eng, engines)
 		return qhCh
@@ -64,13 +67,15 @@ func Test_Collector_Start(t *testing.T) {
 	sentCh := make(chan struct{})
 	go func() {
 		rCh <- fetcher.EngineRuntimePoint{
-			EngineName: "eng1",
-			EventTime:  sql.Null[time.Time]{Valid: true, V: time.Now()},
-			CPUUsed:    sql.NullFloat64{Valid: true, Float64: 10},
+			EngineName:   "eng1",
+			EngineStatus: "RUNNING",
+			EventTime:    sql.Null[time.Time]{Valid: true, V: time.Now()},
+			CPUUsed:      sql.NullFloat64{Valid: true, Float64: 10},
 		}
 
 		qhCh <- fetcher.QueryHistoryPoint{
 			EngineName:           "eng2",
+			EngineStatus:         "RESIZING",
 			DurationMicroSeconds: sql.NullInt64{Valid: true, Int64: 10},
 		}
 		sentCh <- struct{}{}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -56,32 +56,32 @@ func Test_NewCollector_missing_exporter(t *testing.T) {
 }
 
 type fetcherMock struct {
-	fetchEnginesFn            func(ctx context.Context, accountName string) ([]string, error)
-	fetchRuntimePointsFn      func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.EngineRuntimePoint
-	fetchQueryHistoryPointsFn func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.QueryHistoryPoint
+	fetchEnginesFn            func(ctx context.Context, accountName string) ([]fetcher.Engine, error)
+	fetchRuntimePointsFn      func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint
+	fetchQueryHistoryPointsFn func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint
 }
 
 func newFetcherMock() *fetcherMock {
 	return &fetcherMock{
-		fetchEnginesFn: func(ctx context.Context, accountName string) ([]string, error) {
+		fetchEnginesFn: func(ctx context.Context, accountName string) ([]fetcher.Engine, error) {
 			panic("default FetchEngines")
 		},
-		fetchRuntimePointsFn: func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
+		fetchRuntimePointsFn: func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
 			panic("default FetchRuntimePoints")
 		},
-		fetchQueryHistoryPointsFn: func(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
+		fetchQueryHistoryPointsFn: func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 			panic("default FetchQueryHistoryPoints")
 		},
 	}
 }
 
-func (m *fetcherMock) FetchEngines(ctx context.Context, accountName string) ([]string, error) {
+func (m *fetcherMock) FetchEngines(ctx context.Context, accountName string) ([]fetcher.Engine, error) {
 	return m.fetchEnginesFn(ctx, accountName)
 }
-func (m *fetcherMock) FetchRuntimePoints(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
+func (m *fetcherMock) FetchRuntimePoints(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint {
 	return m.fetchRuntimePointsFn(ctx, account, engines, since, till)
 }
-func (m *fetcherMock) FetchQueryHistoryPoints(ctx context.Context, account string, engines []string, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
+func (m *fetcherMock) FetchQueryHistoryPoints(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 	return m.fetchQueryHistoryPointsFn(ctx, account, engines, since, till)
 }
 

--- a/internal/fetcher/model.go
+++ b/internal/fetcher/model.go
@@ -5,9 +5,16 @@ import (
 	"time"
 )
 
+// Engine represents an engine entry, on which metrics are collected
+type Engine struct {
+	Name   string
+	Status string
+}
+
 // EngineRuntimePoint represents a snapshot point of engine runtime metrics.
 type EngineRuntimePoint struct {
-	EngineName string
+	EngineName   string
+	EngineStatus string
 
 	EngineCluster    sql.NullString
 	EventTime        sql.Null[time.Time]
@@ -37,7 +44,8 @@ func (p *EngineRuntimePoint) Scan(row *sql.Row) error {
 
 // QueryHistoryPoint represents a snapshot point of query history metrics for a single query.
 type QueryHistoryPoint struct {
-	EngineName string
+	EngineName   string
+	EngineStatus string
 
 	AccountName sql.NullString
 	UserName    sql.NullString


### PR DESCRIPTION
Previously, the metrics were collected from engines in `RUNNING` status.

Now it is extended to collect metrics from engines in `RESIZING` and `DRAINING` statuses. Also, engine status attribute added to engine runtime and query history metrics.