### PR TITLE
fix: improve gateway time metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ All the instruments in this meter have the following attributes:
 
 ### Meter name: `firebolt.engine.query_history`
 
-| Instrument                    | Type             | Description                                                     |
-|-------------------------------|------------------|-----------------------------------------------------------------|
-| firebolt.query.duration       | Float64Histogram | Duration of query execution (second)                            |
-| firebolt.query.scanned.rows   | Int64Counter     | The total number of rows scanned                                |
-| firebolt.query.scanned.bytes  | Int64Counter     | The total number of bytes scanned (both from cache and storage) |
-| firebolt.query.insert.rows    | Int64Counter     | The total number of rows written                                |
-| firebolt.query.insert.bytes   | Int64Counter     | The total number of bytes written (both to cache and storage)   |
-| firebolt.query.returned.rows  | Int64Counter     | The total number of rows returned from the query                |
-| firebolt.query.returned.bytes | Int64Counter     | The total number of bytes returned from the query               |
-| firebolt.query.spilled.bytes  | Int64Counter     | The total number of bytes spilled (uncompressed)                |
-| firebolt.query.queue.time     | Float64Counter   | Time the query spent in queue                                   |
-| firebolt.query.gateway.time   | Float64Histogram | End to end time the query spent in the gateway                  |
+| Instrument                      | Type             | Description                                                     |
+|---------------------------------|------------------|-----------------------------------------------------------------|
+| firebolt.query.duration         | Float64Histogram | Duration of query execution (second)                            |
+| firebolt.query.scanned.rows     | Int64Counter     | The total number of rows scanned                                |
+| firebolt.query.scanned.bytes    | Int64Counter     | The total number of bytes scanned (both from cache and storage) |
+| firebolt.query.insert.rows      | Int64Counter     | The total number of rows written                                |
+| firebolt.query.insert.bytes     | Int64Counter     | The total number of bytes written (both to cache and storage)   |
+| firebolt.query.returned.rows    | Int64Counter     | The total number of rows returned from the query                |
+| firebolt.query.returned.bytes   | Int64Counter     | The total number of bytes returned from the query               |
+| firebolt.query.spilled.bytes    | Int64Counter     | The total number of bytes spilled (uncompressed)                |
+| firebolt.query.queue.time       | Float64Counter   | Time the query spent in queue                                   |
+| firebolt.query.gateway.duration | Float64Histogram | End to end time the query spent in the gateway (second)         |
 
 All the instruments in this meter have the following attributes:
 - `firebolt.account.name` - name of the account

--- a/internal/collector/collect.go
+++ b/internal/collector/collect.go
@@ -136,7 +136,7 @@ func (c *collector) collectQueryHistoryMetrics(ctx context.Context, wg *sync.Wai
 		c.queryHistoryMetrics.returnedBytes.Add(ctx, mp.ReturnedBytes.Int64, api.WithAttributeSet(attrsSet))
 		c.queryHistoryMetrics.spilledBytes.Add(ctx, mp.SpilledBytes.Int64, api.WithAttributeSet(attrsSet))
 		c.queryHistoryMetrics.queueTime.Add(ctx, float64(mp.TimeInQueueMicroSeconds.Int64)/1000000, api.WithAttributeSet(attrsSet))
-		c.queryHistoryMetrics.gatewayTime.Record(ctx, float64(mp.GatewayDurationMicroSeconds.Int64)/1000000, api.WithAttributeSet(attrsSet))
+		c.queryHistoryMetrics.queryGatewayDuration.Record(ctx, float64(mp.GatewayDurationMicroSeconds.Int64)/1000000, api.WithAttributeSet(attrsSet))
 	}
 
 	wg.Done()

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -40,7 +40,7 @@ func Test_NewCollector(t *testing.T) {
 	require.NotNil(t, c.queryHistoryMetrics.returnedBytes)
 	require.NotNil(t, c.queryHistoryMetrics.spilledBytes)
 	require.NotNil(t, c.queryHistoryMetrics.queueTime)
-	require.NotNil(t, c.queryHistoryMetrics.gatewayTime)
+	require.NotNil(t, c.queryHistoryMetrics.queryGatewayDuration)
 
 	require.NotNil(t, c.exporterMetrics)
 	require.NotNil(t, c.exporterMetrics.duration)

--- a/internal/collector/metric.go
+++ b/internal/collector/metric.go
@@ -27,8 +27,8 @@ type queryHistoryMetrics struct {
 	returnedBytes metric.Int64Counter
 	spilledBytes  metric.Int64Counter
 
-	queueTime   metric.Float64Counter
-	gatewayTime metric.Float64Histogram
+	queueTime            metric.Float64Counter
+	queryGatewayDuration metric.Float64Histogram
 }
 
 // exporterMetrics specifies a set of supplementary metrics of otel-exporter.
@@ -198,8 +198,8 @@ func (c *collector) setupQueryHistoryMetrics() error {
 		return err
 	}
 
-	qhm.gatewayTime, err = meter.Float64Histogram(
-		"firebolt.query.gateway.time",
+	qhm.queryGatewayDuration, err = meter.Float64Histogram(
+		"firebolt.query.gateway.duration",
 		metric.WithDescription("End to end time the query spent in the gateway"),
 		metric.WithUnit("second"),
 	)


### PR DESCRIPTION
Change gateway time metric to follow prometheus rules of naming