### PR TITLE
fix(fetcher): improve engine filtering and SQL execution in metering metrics collection

### DIFF
--- a/internal/collector/collect.go
+++ b/internal/collector/collect.go
@@ -113,10 +113,19 @@ func (c *collector) collectRuntimeMetrics(ctx context.Context, wg *sync.WaitGrou
 }
 
 // collectMeteringMetrics collects and reports FBU consumption per hour per engine from the system engine.
-func (c *collector) collectMeteringMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, _ []fetcher.Engine, since, till time.Time) {
+func (c *collector) collectMeteringMetrics(ctx context.Context, wg *sync.WaitGroup, accountName string, engines []fetcher.Engine, since, till time.Time) {
+
+	defer wg.Done()
+
 	slog.DebugContext(ctx, "start collecting metering metrics", slog.String("accountName", accountName))
 
-	pointsCh := c.fetcher.FetchMeteringPoints(ctx, accountName, since, till)
+	// FBU values only served by real engines
+	if len(engines) == 0 {
+		slog.Warn("no running engines found for account", slog.String("accountName", accountName))
+		return
+	}
+
+	pointsCh := c.fetcher.FetchMeteringPoints(ctx, accountName, engines[0], since, till)
 
 	for mp := range pointsCh {
 		attrs := []attribute.KeyValue{
@@ -128,8 +137,6 @@ func (c *collector) collectMeteringMetrics(ctx context.Context, wg *sync.WaitGro
 
 		c.meteringMetrics.consumedFBU.Record(ctx, mp.ConsumedFBU.Float64, api.WithAttributeSet(attrsSet))
 	}
-
-	wg.Done()
 
 	slog.DebugContext(ctx, "collecting metering metrics routine finished", slog.String("accountName", accountName))
 }

--- a/internal/collector/collect_test.go
+++ b/internal/collector/collect_test.go
@@ -50,7 +50,7 @@ func Test_Collector_Start(t *testing.T) {
 		return qhCh
 	}
 	mCh := make(chan fetcher.EngineMeteringPoint)
-	f.fetchMeteringPointsFn = func(ctx context.Context, account string, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
+	f.fetchMeteringPointsFn = func(ctx context.Context, account string, engine fetcher.Engine, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
 		require.Equal(t, acctName, account)
 		return mCh
 	}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -64,7 +64,7 @@ type fetcherMock struct {
 	fetchEnginesFn            func(ctx context.Context, accountName string) ([]fetcher.Engine, error)
 	fetchRuntimePointsFn      func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint
 	fetchQueryHistoryPointsFn func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint
-	fetchMeteringPointsFn     func(ctx context.Context, account string, since, till time.Time) <-chan fetcher.EngineMeteringPoint
+	fetchMeteringPointsFn     func(ctx context.Context, account string, engine fetcher.Engine, since, till time.Time) <-chan fetcher.EngineMeteringPoint
 }
 
 func newFetcherMock() *fetcherMock {
@@ -78,7 +78,7 @@ func newFetcherMock() *fetcherMock {
 		fetchQueryHistoryPointsFn: func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 			panic("default FetchQueryHistoryPoints")
 		},
-		fetchMeteringPointsFn: func(ctx context.Context, account string, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
+		fetchMeteringPointsFn: func(ctx context.Context, account string, engine fetcher.Engine, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
 			panic("default FetchMeteringPoints")
 		},
 	}
@@ -93,8 +93,8 @@ func (m *fetcherMock) FetchRuntimePoints(ctx context.Context, account string, en
 func (m *fetcherMock) FetchQueryHistoryPoints(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 	return m.fetchQueryHistoryPointsFn(ctx, account, engines, since, till)
 }
-func (m *fetcherMock) FetchMeteringPoints(ctx context.Context, account string, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
-	return m.fetchMeteringPointsFn(ctx, account, since, till)
+func (m *fetcherMock) FetchMeteringPoints(ctx context.Context, account string, engine fetcher.Engine, since, till time.Time) <-chan fetcher.EngineMeteringPoint {
+	return m.fetchMeteringPointsFn(ctx, account, engine, since, till)
 }
 
 type exporterMock struct {

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -31,7 +31,7 @@ type Fetcher interface {
 	// It should close the channel when all data points are pushed.
 	// It queries the system engine (account-level view) for FBU consumption per engine per hour.
 	// The metrics should be collected within the provided time interval.
-	FetchMeteringPoints(ctx context.Context, account string, since, till time.Time) <-chan EngineMeteringPoint
+	FetchMeteringPoints(ctx context.Context, account string, engine Engine, since, till time.Time) <-chan EngineMeteringPoint
 }
 
 // fetcher is an implementation of Fetcher interface.
@@ -269,14 +269,14 @@ func (f *fetcher) FetchQueryHistoryPoints(ctx context.Context, account string, e
 }
 
 // FetchMeteringPoints returns a channel of EngineMeteringPoint by querying the system engine.
-func (f *fetcher) FetchMeteringPoints(ctx context.Context, account string, since, till time.Time) <-chan EngineMeteringPoint {
+func (f *fetcher) FetchMeteringPoints(ctx context.Context, account string, engine Engine, _, _ time.Time) <-chan EngineMeteringPoint {
 	ch := make(chan EngineMeteringPoint)
 
 	go func() {
 		defer close(ch)
 
 		// connect to system engine (empty engine name) — metering_history is an account-level view.
-		db, err := f.connect(ctx, account, "")
+		db, err := f.connect(ctx, account, engine.Name)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to connect to system engine for metering",
 				slog.String("accountName", account),
@@ -293,16 +293,12 @@ func (f *fetcher) FetchMeteringPoints(ctx context.Context, account string, since
 			}
 		}()
 
-		// Metering is in hourly buckets; (since, till] is usually a short window (e.g. 1 min).
-		// Include any hour that overlaps the window: start_hour < till AND end_hour > since.
-		rows, err := db.QueryContext(ctx,
-			fmt.Sprintf(
-				`SELECT engine_name, start_hour, end_hour, consumed_fbu
-				FROM information_schema.engine_metering_history
-				WHERE start_hour < TIMESTAMPTZ '%s' AND end_hour > TIMESTAMPTZ '%s'
-				ORDER BY start_hour;`,
-				till.Format(time.DateTime+"-07"), since.Format(time.DateTime+"-07"),
-			),
+		rows, err := db.QueryContext(
+			ctx,
+			`SELECT engine_name, start_hour, end_hour, consumed_fbu
+					FROM information_schema.engine_metering_history
+					WHERE start_hour = DATE_TRUNC('hour', NOW()) 
+					  AND end_hour =  DATE_TRUNC('hour', NOW() + INTERVAL '1 hour');`,
 		)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to query engine metering history",


### PR DESCRIPTION
- Updated `collectMeteringMetrics` to handle empty engine lists and avoid unnecessary processing.
- Modified `FetchMeteringPoints` to query data for a specific engine instead of system-level queries.
- Adjusted SQL query to fetch metrics for the current hour range, improving query accuracy.